### PR TITLE
Add product ids list to the threat model and revision history to the vulnerability model

### DIFF
--- a/src/main/java/es/mdbdev/cvrfparser/model/cvrf/common/Revision.java
+++ b/src/main/java/es/mdbdev/cvrfparser/model/cvrf/common/Revision.java
@@ -1,4 +1,4 @@
-package es.mdbdev.cvrfparser.model.cvrf.documenttracking;
+package es.mdbdev.cvrfparser.model.cvrf.common;
 
 /**
  * Created by Mario on 28/01/2017.

--- a/src/main/java/es/mdbdev/cvrfparser/model/cvrf/common/RevisionHistory.java
+++ b/src/main/java/es/mdbdev/cvrfparser/model/cvrf/common/RevisionHistory.java
@@ -1,4 +1,4 @@
-package es.mdbdev.cvrfparser.model.cvrf.documenttracking;
+package es.mdbdev.cvrfparser.model.cvrf.common;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/es/mdbdev/cvrfparser/model/cvrf/documenttracking/DocumentTracking.java
+++ b/src/main/java/es/mdbdev/cvrfparser/model/cvrf/documenttracking/DocumentTracking.java
@@ -1,5 +1,7 @@
 package es.mdbdev.cvrfparser.model.cvrf.documenttracking;
 
+import es.mdbdev.cvrfparser.model.cvrf.common.RevisionHistory;
+
 /**
  * Created by Mario on 28/01/2017.
  */

--- a/src/main/java/es/mdbdev/cvrfparser/model/cvrf/vulnerability/Threat.java
+++ b/src/main/java/es/mdbdev/cvrfparser/model/cvrf/vulnerability/Threat.java
@@ -1,9 +1,17 @@
 package es.mdbdev.cvrfparser.model.cvrf.vulnerability;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by Mario de Benito on 30/01/2017.
  */
 public class Threat {
+
+    public Threat() {
+        this.productIDs = new ArrayList<String>();
+    }
+    
     public String getType() {
         return type;
     }
@@ -27,8 +35,21 @@ public class Threat {
     public void setDescription(String description) {
         this.description = description;
     }
+    
+    public List<String> getProductIDs() {
+        return productIDs;
+    }
+
+    public void setProductIDs(List<String> productIDs) {
+        this.productIDs = productIDs;
+    }
+
+    public void addProductID(String p){
+        this.productIDs.add(p);
+    }
 
     private String type;
     private String date;
     private String description;
+    private List<String> productIDs;
 }

--- a/src/main/java/es/mdbdev/cvrfparser/model/cvrf/vulnerability/Vulnerability.java
+++ b/src/main/java/es/mdbdev/cvrfparser/model/cvrf/vulnerability/Vulnerability.java
@@ -1,5 +1,7 @@
 package es.mdbdev.cvrfparser.model.cvrf.vulnerability;
 
+import es.mdbdev.cvrfparser.model.cvrf.common.RevisionHistory;
+
 /**
  * Created by Mario on 28/01/2017.
  */
@@ -26,6 +28,8 @@ public class Vulnerability
     private String Title;
 
     private ProductStatuses ProductStatuses;
+    
+    private RevisionHistory RevisionHistory;
 
     public Notes getNotes ()
     {
@@ -130,12 +134,22 @@ public class Vulnerability
     public Threats getThreats() {
         return threats;
     }
+    
+    public RevisionHistory getRevisionHistory ()
+    {
+        return RevisionHistory;
+    }
+
+    public void setRevisionHistory (RevisionHistory RevisionHistory)
+    {
+        this.RevisionHistory = RevisionHistory;
+    }
 
 
     @Override
     public String toString()
     {
-        return "ClassPojo [Notes = "+Notes+", CVSSScoreSets = "+CVSSScoreSets+", Ordinal = "+Ordinal+", References = "+References+", ID = "+ID+", Remediations = "+Remediations+", xmlns = "+xmlns+", CVE = "+CVE+", Title = "+Title+", ProductStatuses = "+ProductStatuses+"]";
+        return "ClassPojo [Notes = "+Notes+", CVSSScoreSets = "+CVSSScoreSets+", Ordinal = "+Ordinal+", References = "+References+", ID = "+ID+", Remediations = "+Remediations+", xmlns = "+xmlns+", CVE = "+CVE+", Title = "+Title+", ProductStatuses = "+ProductStatuses+", RevisionHistory = "+RevisionHistory+"]";
     }
 
     public void setThreats(Threats threats) {

--- a/src/main/java/es/mdbdev/cvrfparser/xml/CvrfParser.java
+++ b/src/main/java/es/mdbdev/cvrfparser/xml/CvrfParser.java
@@ -1,5 +1,7 @@
 package es.mdbdev.cvrfparser.xml;
 
+import es.mdbdev.cvrfparser.model.cvrf.common.Revision;
+import es.mdbdev.cvrfparser.model.cvrf.common.RevisionHistory;
 import es.mdbdev.cvrfparser.model.cvrf.Cvrfdoc;
 import es.mdbdev.cvrfparser.model.cvrf.common.*;
 import es.mdbdev.cvrfparser.model.cvrf.common.Reference;
@@ -89,6 +91,8 @@ public class CvrfParser {
         private boolean bVulnerabilityThreatsThreat = false;
         private boolean bVulnerabilityRemediations = false;
         private boolean bVulnerabilityRemediationsRemediation = false;
+        private boolean bVulnerabilityRevisionHistory = false;
+        private boolean bVulnerabilityRevisionHistoryRevision = false;
         private boolean bDocumentReferences = false;
         private boolean bDocumentReferencesReference = false;
         private boolean bDocumentTracking = false;
@@ -200,6 +204,12 @@ public class CvrfParser {
                 bVulnerabilityRemediationsRemediation = true;
                 crrntVulnerabilityRemediation = new Remediation();
                 crrntVulnerabilityRemediation.setType(attributes.getValue("Type"));
+            }else if ((qName.equalsIgnoreCase("RevisionHistory")&&bVulnerability)) {
+                bVulnerabilityRevisionHistory = true;
+                crrntVulnerability.setRevisionHistory(new RevisionHistory());
+            }else if ((qName.equalsIgnoreCase("Revision")&& bVulnerabilityRevisionHistory)) {
+                bVulnerabilityRevisionHistoryRevision = true;
+                crrntRev = new Revision();
             }
         }
 
@@ -328,6 +338,18 @@ public class CvrfParser {
                 crrntVulnerabilityRemediation.setDescription(chars.toString());
             }else if ((qName.equalsIgnoreCase("URL") && bVulnerabilityRemediationsRemediation)) {
                 crrntVulnerabilityRemediation.setURL(chars.toString());
+            }else if ((qName.equalsIgnoreCase("RevisionHistory")&&bVulnerability)) {
+                bVulnerabilityRevisionHistory = false;
+            }else if ((qName.equalsIgnoreCase("Revision")&& bVulnerabilityRevisionHistory)) {
+                crrntVulnerability.getRevisionHistory().addRevision(crrntRev);
+                crrntRev = null;
+                bVulnerabilityRevisionHistoryRevision = false;
+            }else if ((qName.equalsIgnoreCase("Number") && bVulnerabilityRevisionHistoryRevision)) {
+                crrntRev.setNumber(chars.toString());
+            }else if ((qName.equalsIgnoreCase("Date") && bVulnerabilityRevisionHistoryRevision)) {
+                crrntRev.setDate(chars.toString());
+            }else if ((qName.equalsIgnoreCase("Description") && bVulnerabilityRevisionHistoryRevision)) {
+                crrntRev.setDescription(chars.toString());
             }
         }
 

--- a/src/main/java/es/mdbdev/cvrfparser/xml/CvrfParser.java
+++ b/src/main/java/es/mdbdev/cvrfparser/xml/CvrfParser.java
@@ -316,6 +316,8 @@ public class CvrfParser {
                 crrntVulnerabilityThreat = null;
             }else if ((qName.equalsIgnoreCase("Description") && bVulnerabilityThreatsThreat)) {
                 crrntVulnerabilityThreat.setDescription(chars.toString());
+            }else if ((qName.equalsIgnoreCase("ProductID") && bVulnerabilityThreatsThreat)) {
+                crrntVulnerabilityThreat.addProductID(chars.toString());
             }else if ((qName.equalsIgnoreCase("Remediations") && bVulnerability)) {
                 bVulnerabilityRemediations = false;
             }else if ((qName.equalsIgnoreCase("Remediation") && bVulnerabilityRemediations)) {


### PR DESCRIPTION
* threat can contain product ids list SEE: http://docs.oasis-open.org/csaf/csaf-cvrf/v1.2/cs01/csaf-cvrf-v1.2-cs01.html#_Toc493508930
* unable to find reference about vulnerability containing  a revision history but cvrf feeds published by microsoft contiain it SEE https://portal.msrc.microsoft.com/en-us/developer